### PR TITLE
Remove Rust from the list

### DIFF
--- a/www/_posts/2015-03-04-make-a-lisp-in-nim.markdown
+++ b/www/_posts/2015-03-04-make-a-lisp-in-nim.markdown
@@ -57,7 +57,6 @@ as you can see. So it's pretty nice to see idiomatic Nim performing well:
     ocaml            1      3        7063
     cs              10     11        5414
     vb              12     13        4523
-    rust             2      5        4084
     c                1      4        3649
     go               1      6        3048
     racket           3     10        2461
@@ -105,7 +104,6 @@ Python shows how much I oriented on the Python implementation
     forth            1609    6826   44715
     cs               1249    4136   45039
     java             1591    4966   53223
-    rust             1897    5702   56516
     vb               1556    5175   58099
     make             1593    6055   62310
     c                2304    6957   73047


### PR DESCRIPTION
To go along with https://github.com/kanaka/mal/pull/23, I don't think that the Rust example here is representative, and so is better to just remove.
